### PR TITLE
Improve heatmap layer

### DIFF
--- a/R/coord-ip.R
+++ b/R/coord-ip.R
@@ -72,6 +72,7 @@ coord_ip <- function(canvas_network = ip_network("0.0.0.0/0"),
                      curve = c("hilbert", "morton"),
                      expand = TRUE) {
 
+  curve <- arg_match(curve)
   curve_order <- as.integer((pixel_prefix - prefix_length(canvas_network)) / 2)
   lim <- as.integer(c(0, 2 ^ curve_order - 1))
 

--- a/R/stat-ip-heatmap.R
+++ b/R/stat-ip-heatmap.R
@@ -8,16 +8,19 @@
 #'  - `z`: Value passed to the summary function (only required if `fun != "count"`).
 #' @section Computed variables:
 #'  - `value`: Value of summary statistic
+#'  - `count`
+#'  - `proportion`
+#' @section Summary function:
+#'
 #'
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_point
 #' @param fun Summary function
 #' @param fun.args A list of extra arguments to pass to `fun`
-#' @param drop if `TRUE` removes all cells with 0 counts.
 #' @export
 stat_ip_heatmap <- function(mapping = NULL, data = NULL, geom = "raster",
                             position = "identity", ...,
-                            fun = "count", fun.args = list(), drop = TRUE,
+                            fun = "count", fun.args = list(),
                             na.rm = FALSE, show.legend = NA,
                             inherit.aes = TRUE) {
   ggplot2::layer(
@@ -27,7 +30,6 @@ stat_ip_heatmap <- function(mapping = NULL, data = NULL, geom = "raster",
       na.rm = na.rm,
       fun = fun,
       fun.args = fun.args,
-      drop = drop,
       ...
     )
   )
@@ -40,7 +42,7 @@ StatIpHeatmap <- ggplot2::ggproto("StatIpHeatmap", ggplot2::Stat,
 
   extra_params = c(
     "na.rm",
-    "fun", "fun.args", "drop"
+    "fun", "fun.args"
   ),
 
   compute_layer = function(self, data, params, layout) {
@@ -54,49 +56,48 @@ StatIpHeatmap <- ggplot2::ggproto("StatIpHeatmap", ggplot2::Stat,
   },
 
   compute_group = function(data, scales, coord,
-                           fun = "count", fun.args = list(), drop = TRUE,
-                           ...) {
-    if (is_formula(fun)) {
-      fun <- as_function(fun)
-    }
-
-    out <- if (is_scalar_character(fun) && fun == "count") {
-      tapply_df(data$x, list(x = data$x, y = data$y), length, drop = drop)
-    } else {
-      f <- function(x) do.call(fun, c(list(quote(x)), fun.args))
-      tapply_df(data$z, list(x = data$x, y = data$y), f, drop = drop)
-    }
-
-    # fill missing pixels so raster works
-    x_range <- seq(coord$limits$x[1], coord$limits$x[2])
-    y_range <- seq(coord$limits$y[1], coord$limits$y[2])
-    tidyr::complete(out, tidyr::expand(out, x = x_range, y = y_range))
+                           fun = "count", fun.args = list(), ...) {
+    summarize_grid(data, coord = coord, fun = fun, fun.args = fun.args)
   }
 )
 
-# Copied from ggplot2
-ulevels <- function(x) {
-  if (is.factor(x)) {
-    x <- addNA(x, TRUE)
-    factor(levels(x), levels(x), exclude = NULL)
+summarize_grid <- function(data, coord, fun, fun.args) {
+  # support formula interface
+  if (is_formula(fun)) {
+    fun <- as_function(fun)
+  }
+
+  summarize_count <- is_scalar_character(fun) && fun == "count"
+  if (!summarize_count && !("z" %in% colnames(data))) {
+    abort("stat_ip_heatmap() requires `z` aesthetic when using non-default summary function")
+  }
+
+  # summarize grid found in data
+  index <- list(x = data$x, y = data$y)
+  labels <- lapply(index, function(x) sort(unique(x)))
+  grps <- if (summarize_count) {
+    split(data$x, index)
   } else {
-    sort(unique(x))
+    split(data$z, index)
   }
-}
-
-# Adaptation of tapply that returns a data frame instead of a matrix
-tapply_df <- function(x, index, fun, ..., drop = TRUE) {
-  labels <- lapply(index, ulevels)
-  out <- expand.grid(labels, KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)
-
-  grps <- split(x, index)
   names(grps) <- NULL
-  out$value <- unlist(lapply(grps, fun, ...))
 
-  if (drop) {
-    n <- vapply(grps, length, integer(1))
-    out <- out[n > 0, , drop = FALSE]
+  out <- expand.grid(labels, KEEP.OUT.ATTRS = FALSE)
+  out$count <- vapply(grps, length, integer(1))
+  bits_per_pixel <- max_prefix_length(coord$canvas_network) - coord$pixel_prefix
+  out$proportion <- out$count / (2^bits_per_pixel)
+  out$value <- if (summarize_count) {
+    out$count
+  } else {
+    f <- function(x) do.call(fun, c(list(quote(x)), fun.args))
+    unlist(lapply(grps, f))
   }
 
-  out
+  # fill remaining grid so raster works
+  range <- coord$limits$x[1]:coord$limits$x[2]
+  fill_na <- list(count = 0, proportion = 0)
+  if (summarize_count) {
+    fill_na$value <- 0
+  }
+  tidyr::complete(out, tidyr::expand(out, x = range, y = range), fill = fill_na)
 }

--- a/R/stat-ip-heatmap.R
+++ b/R/stat-ip-heatmap.R
@@ -1,18 +1,18 @@
 #' Heatmap of IP data
 #'
 #' @section Aesthetics:
-#' `stat_ip_heatmap()` understands the following aesthetics (required aesthetics
-#' are in bold):
-#'  - **`x`**
-#'  - **`y`**
+#' `stat_ip_heatmap()` understands the following aesthetics:
+#'  - `ip`: An [`ip_address`][`ipaddress::ip_address`] column
 #'  - `z`: Value passed to the summary function (required if `fun` is used)
 #'  - `fill`: Must use a computed variable (default: `after_stat(value)`)
-#'  - `ip`: [`ip_address`][`ipaddress::ip_address`] vector associated with `x`
-#'    and `y` aesthetics. Required if `ip_count` or `ip_propn` computed variable
-#'    is used.
+#'
+#' *Note:* Since this is a native ggip layer, it can accept an
+#' [`ip_address`][`ipaddress::ip_address`] column directly. It works together
+#' with [coord_ip()] to ensure IP data are correctly mapped to the `x` and `y`
+#' aesthetics.
 #'
 #' @section Computed variables:
-#' The following variables are available to [ggplot2::after_stat()]:
+#' The following variables are available to [`after_stat()`][ggplot2::after_stat()]:
 #'  - `value`: Value of summary statistic
 #'  - `count`: Number of observations
 #'  - `ip_count`: Number of unique addresses
@@ -38,35 +38,41 @@
 #'
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_point
+#' @param mapping Set of aesthetic mappings created by [`aes()`][ggplot2::aes()].
+#'   Note `stat_ip_heatmap()` does not inherit the default mapping specified in
+#'   [`ggplot()`][ggplot2::ggplot()], so these *must* be defined here.
 #' @param fun Summary function (see section below for details). If `NULL` (the
 #'   default), the number of observations is computed.
 #' @param fun.args A list of extra arguments to pass to `fun`
 #' @export
 stat_ip_heatmap <- function(mapping = NULL, data = NULL,
-                            ...,
                             fun = NULL, fun.args = list(),
-                            na.rm = FALSE, show.legend = NA,
-                            inherit.aes = TRUE) {
+                            na.rm = FALSE, show.legend = NA) {
+  if (is.null(mapping$ip)) {
+    abort("stat_ip_heatmap() requires `ip` aesthetic")
+  }
+
+  # extract {x, y, ip} aesthetics from ip aesthetic
+  ip_col <- as_name(mapping$ip)
+  mapping$x <- parse_expr(paste0(ip_col, "$x"))
+  mapping$y <- parse_expr(paste0(ip_col, "$y"))
+  mapping$ip <- parse_expr(paste0(ip_col, "$ip"))
+
   ggplot2::layer(
     stat = StatIpHeatmap, data = data, mapping = mapping, geom = "raster",
-    position = "identity", show.legend = show.legend, inherit.aes = inherit.aes,
+    position = "identity", show.legend = show.legend, inherit.aes = FALSE,
     params = list(
       na.rm = na.rm,
       fun = fun,
-      fun.args = fun.args,
-      ...
+      fun.args = fun.args
     )
   )
 }
 
 StatIpHeatmap <- ggplot2::ggproto("StatIpHeatmap", ggplot2::Stat,
-  required_aes = c("x", "y"),
+  required_aes = c("x", "y", "ip"),
 
-  default_aes = ggplot2::aes(
-    z = NULL,
-    ip = NULL,
-    fill = ggplot2::after_stat(value)
-  ),
+  default_aes = ggplot2::aes(z = NULL, fill = ggplot2::after_stat(value)),
 
   extra_params = c(
     "na.rm",
@@ -76,6 +82,10 @@ StatIpHeatmap <- ggplot2::ggproto("StatIpHeatmap", ggplot2::Stat,
   compute_layer = function(self, data, params, layout) {
     if (!is_CoordIp(layout$coord)) {
       abort("Must call coord_ip() when using ggip")
+    }
+
+    if (!is_ip_address(data$ip)) {
+      abort("stat_ip_heatmap requires `ip` aesthetic to be an ip_address vector")
     }
 
     # add coord to the params, so it can be forwarded to compute_group()
@@ -97,7 +107,7 @@ compute_ip_heatmap <- function(data, coord, fun, fun.args) {
 
   summarize_count <- is.null(fun)
   if (!summarize_count && !("z" %in% colnames(data))) {
-    abort("stat_ip_heatmap() requires `z` aesthetic when using non-default summary function")
+    abort("stat_ip_heatmap requires `z` aesthetic when using non-default summary function")
   }
 
   # summarize grid found in data

--- a/R/stat-ip-heatmap.R
+++ b/R/stat-ip-heatmap.R
@@ -5,22 +5,40 @@
 #' are in bold):
 #'  - **`x`**
 #'  - **`y`**
-#'  - `z`: Value passed to the summary function (only required if `fun != "count"`).
+#'  - `z`: Value passed to the summary function (required if `fun` is used)
+#'  - `ip`: [`ip_address`][`ipaddress::ip_address`] vector
 #' @section Computed variables:
-#'  - `value`: Value of summary statistic
-#'  - `count`
-#'  - `proportion`
+#'  - `value`: Value of summary statistic (or `count` if `fun` not used)
+#'  - `count`: Number of observations
+#'  - `address_count`: Number of unique addresses
+#'  - `address_proportion`: Observed proportion of total addresses
 #' @section Summary function:
+#' The `data` might contain multiple rows per pixel of the heatmap, so we use
+#' a summary function to reduce this information to a single value to display.
+#' This function receives the `data` column specified by the `z` aesthetic
+#' and will also receive arguments specified by `fun.args`.
 #'
+#' The `fun` argument can be specified in multiple ways:
+#' \describe{
+#' \item{`NULL`}{If no summary function is provided, the number of observations
+#'   is computed. In this case, you don't need to specify the `z` aesthetic,
+#'   and the computed variables `value` and `count` will be equal.}
+#' \item{String}{The name of an existing function (e.g. `fun = "mean"`).}
+#' \item{Function}{Either provide an existing function (e.g. `fun = mean`) or
+#'   define a new function (e.g. `fun = function(x) sum(x^2)`).}
+#' \item{Formula}{A function can also be created from a formula. This uses `.x`
+#'   as the summarized variable (e.g. `fun = ~ sum(.x^2)`).}
+#' }
 #'
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_point
-#' @param fun Summary function
+#' @param fun Summary function (see section below for details). If `NULL` (the
+#'   default), the number of observations is computed.
 #' @param fun.args A list of extra arguments to pass to `fun`
 #' @export
 stat_ip_heatmap <- function(mapping = NULL, data = NULL, geom = "raster",
                             position = "identity", ...,
-                            fun = "count", fun.args = list(),
+                            fun = NULL, fun.args = list(),
                             na.rm = FALSE, show.legend = NA,
                             inherit.aes = TRUE) {
   ggplot2::layer(
@@ -38,7 +56,11 @@ stat_ip_heatmap <- function(mapping = NULL, data = NULL, geom = "raster",
 StatIpHeatmap <- ggplot2::ggproto("StatIpHeatmap", ggplot2::Stat,
   required_aes = c("x", "y"),
 
-  default_aes = ggplot2::aes(z = NULL, fill = ggplot2::after_stat(value)),
+  default_aes = ggplot2::aes(
+    z = NULL,
+    ip = NULL,
+    fill = ggplot2::after_stat(value)
+    ),
 
   extra_params = c(
     "na.rm",
@@ -56,18 +78,18 @@ StatIpHeatmap <- ggplot2::ggproto("StatIpHeatmap", ggplot2::Stat,
   },
 
   compute_group = function(data, scales, coord,
-                           fun = "count", fun.args = list(), ...) {
-    summarize_grid(data, coord = coord, fun = fun, fun.args = fun.args)
+                           fun = NULL, fun.args = list(), ...) {
+    compute_ip_heatmap(data, coord = coord, fun = fun, fun.args = fun.args)
   }
 )
 
-summarize_grid <- function(data, coord, fun, fun.args) {
+compute_ip_heatmap <- function(data, coord, fun, fun.args) {
   # support formula interface
   if (is_formula(fun)) {
     fun <- as_function(fun)
   }
 
-  summarize_count <- is_scalar_character(fun) && fun == "count"
+  summarize_count <- is.null(fun)
   if (!summarize_count && !("z" %in% colnames(data))) {
     abort("stat_ip_heatmap() requires `z` aesthetic when using non-default summary function")
   }
@@ -75,22 +97,21 @@ summarize_grid <- function(data, coord, fun, fun.args) {
   # summarize grid found in data
   index <- list(x = data$x, y = data$y)
   labels <- lapply(index, function(x) sort(unique(x)))
-  grps <- if (summarize_count) {
-    split(data$x, index)
-  } else {
-    split(data$z, index)
-  }
-  names(grps) <- NULL
-
   out <- expand.grid(labels, KEEP.OUT.ATTRS = FALSE)
-  out$count <- vapply(grps, length, integer(1))
-  bits_per_pixel <- max_prefix_length(coord$canvas_network) - coord$pixel_prefix
-  out$proportion <- out$count / (2^bits_per_pixel)
+
+  out$count <- summarize_grid(data$x, index, length)
   out$value <- if (summarize_count) {
     out$count
   } else {
     f <- function(x) do.call(fun, c(list(quote(x)), fun.args))
-    unlist(lapply(grps, f))
+    summarize_grid(data$z, index, f)
+  }
+  if ("ip" %in% colnames(data)) {
+    f <- function(x) length(unique(x))
+    out$address_count <- summarize_grid(data$ip, index, f)
+
+    bits_per_pixel <- max_prefix_length(coord$canvas_network) - coord$pixel_prefix
+    out$address_proportion <- out$address_count / (2^bits_per_pixel)
   }
 
   # fill remaining grid so raster works
@@ -100,4 +121,10 @@ summarize_grid <- function(data, coord, fun, fun.args) {
     fill_na$value <- 0
   }
   tidyr::complete(out, tidyr::expand(out, x = range, y = range), fill = fill_na)
+}
+
+summarize_grid <- function(x, index, fun) {
+  grps <- split(x, index)
+  names(grps) <- NULL
+  unlist(lapply(grps, fun))
 }

--- a/man/stat_ip_heatmap.Rd
+++ b/man/stat_ip_heatmap.Rd
@@ -7,8 +7,6 @@
 stat_ip_heatmap(
   mapping = NULL,
   data = NULL,
-  geom = "raster",
-  position = "identity",
   ...,
   fun = NULL,
   fun.args = list(),
@@ -37,11 +35,6 @@ A \code{function} will be called with a single argument,
 the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
-
-\item{geom}{The geometric object to use display the data}
-
-\item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
@@ -78,36 +71,40 @@ are in bold):
 \item \strong{\code{x}}
 \item \strong{\code{y}}
 \item \code{z}: Value passed to the summary function (required if \code{fun} is used)
-\item \code{ip}: \code{\link[ipaddress:ip_address]{ip_address}} vector
+\item \code{fill}: Must use a computed variable (default: \code{after_stat(value)})
+\item \code{ip}: \code{\link[ipaddress:ip_address]{ip_address}} vector associated with \code{x}
+and \code{y} aesthetics. Required if \code{ip_count} or \code{ip_propn} computed variable
+is used.
 }
 }
 
 \section{Computed variables}{
 
+The following variables are available to \code{\link[ggplot2:aes_eval]{ggplot2::after_stat()}}:
 \itemize{
-\item \code{value}: Value of summary statistic (or \code{count} if \code{fun} not used)
+\item \code{value}: Value of summary statistic
 \item \code{count}: Number of observations
-\item \code{address_count}: Number of unique addresses
-\item \code{address_proportion}: Observed proportion of total addresses
+\item \code{ip_count}: Number of unique addresses
+\item \code{ip_propn}: Observed proportion of network
 }
 }
 
 \section{Summary function}{
 
-The \code{data} might contain multiple rows per pixel of the heatmap, so we use
-a summary function to reduce this information to a single value to display.
+The \code{data} might contain multiple rows per pixel of the heatmap, so a summary
+function reduces this information to a single value to display.
 This function receives the \code{data} column specified by the \code{z} aesthetic
-and will also receive arguments specified by \code{fun.args}.
+and also receives arguments specified by \code{fun.args}.
 
 The \code{fun} argument can be specified in multiple ways:
 \describe{
 \item{\code{NULL}}{If no summary function is provided, the number of observations
 is computed. In this case, you don't need to specify the \code{z} aesthetic,
 and the computed variables \code{value} and \code{count} will be equal.}
-\item{String}{The name of an existing function (e.g. \code{fun = "mean"}).}
-\item{Function}{Either provide an existing function (e.g. \code{fun = mean}) or
+\item{string}{The name of an existing function (e.g. \code{fun = "mean"}).}
+\item{function}{Either provide an existing function (e.g. \code{fun = mean}) or
 define a new function (e.g. \code{fun = function(x) sum(x^2)}).}
-\item{Formula}{A function can also be created from a formula. This uses \code{.x}
+\item{formula}{A function can also be created from a formula. This uses \code{.x}
 as the summarized variable (e.g. \code{fun = ~ sum(.x^2)}).}
 }
 }

--- a/man/stat_ip_heatmap.Rd
+++ b/man/stat_ip_heatmap.Rd
@@ -10,7 +10,7 @@ stat_ip_heatmap(
   geom = "raster",
   position = "identity",
   ...,
-  fun = "count",
+  fun = NULL,
   fun.args = list(),
   na.rm = FALSE,
   show.legend = NA,
@@ -48,7 +48,8 @@ often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
-\item{fun}{Summary function}
+\item{fun}{Summary function (see section below for details). If \code{NULL} (the
+default), the number of observations is computed.}
 
 \item{fun.args}{A list of extra arguments to pass to \code{fun}}
 
@@ -76,20 +77,38 @@ are in bold):
 \itemize{
 \item \strong{\code{x}}
 \item \strong{\code{y}}
-\item \code{z}: Value passed to the summary function (only required if \code{fun != "count"}).
+\item \code{z}: Value passed to the summary function (required if \code{fun} is used)
+\item \code{ip}: \code{\link[ipaddress:ip_address]{ip_address}} vector
 }
 }
 
 \section{Computed variables}{
 
 \itemize{
-\item \code{value}: Value of summary statistic
-\item \code{count}
-\item \code{proportion}
+\item \code{value}: Value of summary statistic (or \code{count} if \code{fun} not used)
+\item \code{count}: Number of observations
+\item \code{address_count}: Number of unique addresses
+\item \code{address_proportion}: Observed proportion of total addresses
 }
 }
 
 \section{Summary function}{
 
+The \code{data} might contain multiple rows per pixel of the heatmap, so we use
+a summary function to reduce this information to a single value to display.
+This function receives the \code{data} column specified by the \code{z} aesthetic
+and will also receive arguments specified by \code{fun.args}.
+
+The \code{fun} argument can be specified in multiple ways:
+\describe{
+\item{\code{NULL}}{If no summary function is provided, the number of observations
+is computed. In this case, you don't need to specify the \code{z} aesthetic,
+and the computed variables \code{value} and \code{count} will be equal.}
+\item{String}{The name of an existing function (e.g. \code{fun = "mean"}).}
+\item{Function}{Either provide an existing function (e.g. \code{fun = mean}) or
+define a new function (e.g. \code{fun = function(x) sum(x^2)}).}
+\item{Formula}{A function can also be created from a formula. This uses \code{.x}
+as the summarized variable (e.g. \code{fun = ~ sum(.x^2)}).}
+}
 }
 

--- a/man/stat_ip_heatmap.Rd
+++ b/man/stat_ip_heatmap.Rd
@@ -12,7 +12,6 @@ stat_ip_heatmap(
   ...,
   fun = "count",
   fun.args = list(),
-  drop = TRUE,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -53,8 +52,6 @@ to the paired geom/stat.}
 
 \item{fun.args}{A list of extra arguments to pass to \code{fun}}
 
-\item{drop}{if \code{TRUE} removes all cells with 0 counts.}
-
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}
 
@@ -87,6 +84,12 @@ are in bold):
 
 \itemize{
 \item \code{value}: Value of summary statistic
+\item \code{count}
+\item \code{proportion}
 }
+}
+
+\section{Summary function}{
+
 }
 

--- a/man/stat_ip_heatmap.Rd
+++ b/man/stat_ip_heatmap.Rd
@@ -7,19 +7,16 @@
 stat_ip_heatmap(
   mapping = NULL,
   data = NULL,
-  ...,
   fun = NULL,
   fun.args = list(),
   na.rm = FALSE,
-  show.legend = NA,
-  inherit.aes = TRUE
+  show.legend = NA
 )
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
-\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}.
+Note \code{stat_ip_heatmap()} does not inherit the default mapping specified in
+\code{\link[ggplot2:ggplot]{ggplot()}}, so these \emph{must} be defined here.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
@@ -36,11 +33,6 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}. These are
-often aesthetics, used to set an aesthetic to a fixed value, like
-\code{colour = "red"} or \code{size = 3}. They may also be parameters
-to the paired geom/stat.}
-
 \item{fun}{Summary function (see section below for details). If \code{NULL} (the
 default), the number of observations is computed.}
 
@@ -54,33 +46,28 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
 display.}
-
-\item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
-rather than combining with them. This is most useful for helper functions
-that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
 }
 \description{
 Heatmap of IP data
 }
 \section{Aesthetics}{
 
-\code{stat_ip_heatmap()} understands the following aesthetics (required aesthetics
-are in bold):
+\code{stat_ip_heatmap()} understands the following aesthetics:
 \itemize{
-\item \strong{\code{x}}
-\item \strong{\code{y}}
+\item \code{ip}: An \code{\link[ipaddress:ip_address]{ip_address}} column
 \item \code{z}: Value passed to the summary function (required if \code{fun} is used)
 \item \code{fill}: Must use a computed variable (default: \code{after_stat(value)})
-\item \code{ip}: \code{\link[ipaddress:ip_address]{ip_address}} vector associated with \code{x}
-and \code{y} aesthetics. Required if \code{ip_count} or \code{ip_propn} computed variable
-is used.
 }
+
+\emph{Note:} Since this is a native ggip layer, it can accept an
+\code{\link[ipaddress:ip_address]{ip_address}} column directly. It works together
+with \code{\link[=coord_ip]{coord_ip()}} to ensure IP data are correctly mapped to the \code{x} and \code{y}
+aesthetics.
 }
 
 \section{Computed variables}{
 
-The following variables are available to \code{\link[ggplot2:aes_eval]{ggplot2::after_stat()}}:
+The following variables are available to \code{\link[ggplot2:aes_eval]{after_stat()}}:
 \itemize{
 \item \code{value}: Value of summary statistic
 \item \code{count}: Number of observations

--- a/tests/testthat/test-coord-ip.R
+++ b/tests/testthat/test-coord-ip.R
@@ -3,9 +3,9 @@ context("coord-ip")
 library(ggplot2)
 
 test_that("ipaddress classes passed through ggplot unscaled", {
-  expect_equal(ggplot2::scale_type(ip_address()), "identity")
-  expect_equal(ggplot2::scale_type(ip_network()), "identity")
-  expect_equal(ggplot2::scale_type(ip_interface()), "identity")
+  expect_equal(scale_type(ip_address()), "identity")
+  expect_equal(scale_type(ip_network()), "identity")
+  expect_equal(scale_type(ip_interface()), "identity")
 })
 
 test_that("visual tests of ip_address data", {

--- a/tests/testthat/test-stat-ip-heatmap.R
+++ b/tests/testthat/test-stat-ip-heatmap.R
@@ -1,0 +1,27 @@
+library(ggplot2)
+
+test_that("input validation", {
+  network_data <- data.frame(network = ip_network("0.0.0.0/16"))
+  address_data <- data.frame(address = ip_address("0.0.0.0"))
+
+  # fails when coord_ip() not used
+  # TODO: how can we catch this to produce helpful error message?
+  expect_error(
+    ggplot_build(ggplot(address_data) + stat_ip_heatmap(aes(ip = address))),
+  )
+
+  expect_error(
+    ggplot_build(ggplot(network_data) + stat_ip_heatmap(aes(ip = network)) + coord_ip()),
+    "stat_ip_heatmap requires `ip` aesthetic to be an ip_address vector"
+  )
+
+  expect_error(
+    ggplot_build(ggplot(address_data, aes(ip = address)) + stat_ip_heatmap() + coord_ip()),
+    "stat_ip_heatmap requires `ip` aesthetic"
+  )
+
+  expect_error(
+    ggplot_build(ggplot(address_data) + stat_ip_heatmap(aes(ip = address), fun = sum) + coord_ip()),
+    "stat_ip_heatmap requires `z` aesthetic when using non-default summary function"
+  )
+})


### PR DESCRIPTION
## Computed variables

`stat_ip_heatmap()` now computes multiple variables: `value`, `count`, `ip_count` and `ip_propn`. These make it easier for users to access relevant statistics, without writing new summary functions. In particular, writing a summary function for `ip_propn` is difficult because it depends on the arguments to `coord_ip()`.

## Aesthetics specification

This PR also simplifies the aesthetics specification. In the past, the user needed to specify `x`, `y` and `ip` aesthetics. These corresponded to the 3 columns of the data frame column output by the `coord_ip()` transformation. For example:
```r
aes(x = address$x, y = address$y, ip = address$ip)
```

The user now only needs to specify an `ip` aesthetic, which corresponds to the column of the original input data (and corresponds to the name of the entire data frame column output by `coord_ip()` transformation. For example:
```r
aes(ip = address)
```

The `stat_ip_heatmap()` layer now automatically creates mappings for the 3 required aesthetics (`x`, `y` and `ip`), based upon the expected output of the `coord_ip()` transformation.

This approach has two disadvantages:
* There is now a disparity in the expected aesthetics of ggip layers and external layers. External layers still require that the transformed columns are explicitly specified. However, this disparity is necessary if we want to make ggip layers much simpler to specify.
* I don't have a good way to catch when `stat_ip_heatmap()` is used without `coord_ip()`. This currently outputs an unhelpful error message: `subsetting with $.ip_address() not supported`.

I'm hoping these two disadvantages can be alleviated with good documentation.