### PR TITLE
Prepare for ggplot2 3.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     Rcpp,
     rlang (>= 0.4.2),
     tidyr,
-    vctrs (>= 0.3.0)
+    vctrs (>= 0.5.0)
 Suggests: 
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,8 @@ LinkingTo:
     Rcpp
 VignetteBuilder: 
     knitr
+Remotes:
+    tidyverse/ggplot2@v3.4.0-rc
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # ggip (development version)
 
+Compatible with latest {ggplot2}.
+This introduced a **breaking change**, where an aesthetic of `stat_summary_address()` was renamed from `size` to `linewidth`.
+
+
 # ggip 0.2.2
 
 Minor changes for compatibility with latest {tidyselect}.

--- a/R/geom-hilbert-outline.R
+++ b/R/geom-hilbert-outline.R
@@ -16,7 +16,7 @@
 #'  - `alpha`
 #'  - `colour`
 #'  - `linetype`
-#'  - `size`
+#'  - `linewidth`
 #'
 #' @section Computed variables:
 #'
@@ -72,7 +72,7 @@ GeomHilbertOutline <- ggplot2::ggproto("GeomHilbertOutline", ggplot2::Geom,
     curve_order = 3,
     closed = FALSE,
     colour = "black",
-    size = 0.5,
+    linewidth = 0.5,
     linetype = 1,
     alpha = NA
   ),

--- a/R/stat-summary-address.R
+++ b/R/stat-summary-address.R
@@ -78,16 +78,18 @@ stat_summary_address <- function(mapping = NULL, data = NULL, ...,
 
 StatSummaryAddress <- ggplot2::ggproto("StatSummaryAddress", ggplot2::Stat,
 
+  default_aes = ggplot2::aes(
+   ip = NULL,
+   z = NULL,
+   fill = ggplot2::after_stat(value)
+  ),
+
   # The `ip` aesthetic is required, but putting it in required_aes causes a very
   # slow check for missing values. It's much faster to simply check `x` and `y`
   # for missing values. These are always NA when `ip` is NA.
   required_aes = c("x", "y"),
 
-  default_aes = ggplot2::aes(
-    ip = NULL,
-    z = NULL,
-    fill = ggplot2::after_stat(value)
-  ),
+  dropped_aes = c("ip", "z"),
 
   extra_params = c("na.rm", "fun", "fun.args"),
 

--- a/man/geom_hilbert_outline.Rd
+++ b/man/geom_hilbert_outline.Rd
@@ -69,7 +69,7 @@ entire Hilbert curve is shown.
 \item \code{alpha}
 \item \code{colour}
 \item \code{linetype}
-\item \code{size}
+\item \code{linewidth}
 }
 }
 


### PR DESCRIPTION
Fixes #23. Fixes #24.

Note: this depends on https://github.com/tidyverse/ggplot2/issues/5019 to get the latest version of vctrs.