### PR TITLE
Faster C++ loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # ggip (development version)
 
-Compatible with latest {ggplot2}.
-This introduced a **breaking change**, where an aesthetic of `stat_summary_address()` was renamed from `size` to `linewidth`.
+* Compatible with latest {ggplot2}. This introduced a **breaking change**, where an aesthetic of `stat_summary_address()` was renamed from `size` to `linewidth`.
+* Use {cli} to format error messages.
 
 
 # ggip 0.2.2

--- a/src/address_to_pixel.cpp
+++ b/src/address_to_pixel.cpp
@@ -39,7 +39,7 @@ DataFrame wrap_address_to_cartesian(List address_r, List canvas_network_r, int p
   bool is_morton = (curve == "morton");
 
   for (std::size_t i=0; i<vsize; ++i) {
-    if (i % 10000 == 0) {
+    if (i % 8192 == 0) {
       checkUserInterrupt();
     }
 

--- a/src/network_to_bbox.cpp
+++ b/src/network_to_bbox.cpp
@@ -99,7 +99,7 @@ DataFrame wrap_network_to_cartesian(List network_r, List canvas_network_r, int p
   bool is_morton = (curve == "morton");
 
   for (std::size_t i=0; i<vsize; ++i) {
-    if (i % 10000 == 0) {
+    if (i % 8192 == 0) {
       checkUserInterrupt();
     }
 


### PR DESCRIPTION
Fixes #18 

This performance improvement wasn't observable in typical ggip usage, so the user interrupt check clearly wasn't very important. Nonetheless, we may as well do this consistently with other packages.